### PR TITLE
Sanitize file links with spaces

### DIFF
--- a/src/structures/MessageMedia.js
+++ b/src/structures/MessageMedia.js
@@ -98,8 +98,14 @@ class MessageMedia {
             ? (await options.client.pupPage.evaluate(fetchData, url, options.reqOptions))
             : (await fetchData(url, options.reqOptions));
 
-        const filename = options.filename ||
+        const rawFilename = options.filename ||
             (res.name ? res.name[0] : (pUrl.pathname.split('/').pop() || 'file'));
+        let filename;
+        try {
+            filename = decodeURIComponent(rawFilename);
+        } catch (e) {
+            filename = rawFilename;
+        }
         
         if (!mimetype)
             mimetype = res.mime;

--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -598,7 +598,13 @@ exports.LoadUtils = () => {
         msg.links = window.Store.Validators.findLinks(
             message.mediaObject ? message.caption : message.body,
         ).map((link) => ({
-            link: link.href,
+            link: (() => {
+                try {
+                    return encodeURI(link.href);
+                } catch (e) {
+                    return link.href;
+                }
+            })(),
             isSuspicious: Boolean(
                 link.suspiciousCharacters && link.suspiciousCharacters.size,
             ),


### PR DESCRIPTION
# PR Details

Fixes broken links and incorrect filenames by improving URL and filename sanitization for files with spaces in their names.

## Description

This PR addresses issues where file links were broken or filenames were displayed incorrectly due to improper handling of spaces and special characters.

*   **`src/util/Injected/Utils.js`**: When extracting links from messages, `link.href` is now passed through `encodeURI()`. This ensures that URLs containing spaces or other unsafe characters are properly encoded, preventing broken links.
*   **`src/structures/MessageMedia.js`**: Filenames derived from URLs (e.g., from the URL path or `Content-Disposition` header) are now `decodeURIComponent()`-decoded. This correctly converts percent-encoded characters (like `%20`) back into their original form (e.g., spaces), ensuring filenames are displayed accurately (e.g., "My%20File.pdf" becomes "My File.pdf").

## Related Issue(s)

<!-- Optional --->
<!-- If there is an issue related to the PR, link it here using a 'closes' keyword, for example: -->
<!-- closes #XXXX (where the XXXX is an issue number) -->
<!-- If there are multiple issues, link them as follows: -->
<!-- closes #XXXX closes #YYYY closes #ZZZZ -->
<!-- See more here: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Motivation and Context

This change is required to resolve issues where file download links were non-functional or filenames were displayed incorrectly when they contained spaces or other special characters, leading to a poor user experience.

## How Has This Been Tested

Testing was performed by the AI assistant. Automated tests requiring a real WhatsApp session were not run in this environment.

### Environment

- Machine OS: <!-- The operation system of a machine you tested the PR on. (Mac | Windows | Linux | Docker + Ubuntu | other (provide the type)) -->
- Phone OS: <!-- The operation system of a phone you used to check the the PR functionality on. -->
- Library Version: <!-- The whatsapp-web.js version you used to test the PR. -->
- WhatsApp Web Version: <!-- Run `await client.getWWebVersion()` to see the WWeb version you used to test the PR. -->
- Puppeteer Version:
- Browser Type and Version: <!-- Chromium XX | Google Chrome XX | other (provide the type and version) -->
- Node Version: <!-- Run `npm -v` in your terminal to see the version of Node.js being used. -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `X` in all the boxes that apply: -->

- [ ] Dependency change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!-- Go over all the following points, and put an `X` in all the boxes that apply: -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).
- [ ] I have updated the usage example accordingly (example.js)

---
<a href="https://cursor.com/background-agent?bcId=bc-6527dc81-e8d8-4082-a410-f811d9ddb8a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6527dc81-e8d8-4082-a410-f811d9ddb8a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

